### PR TITLE
Fix informe rendimento field wrong value

### DIFF
--- a/src/automate/downloader.py
+++ b/src/automate/downloader.py
@@ -105,7 +105,6 @@ class Downloader:
         form_data['controlsAscx111$cboFolha'] = 'MENSAL	1'
         form_data['controlsAscx111$txtDataRef'] = self.get_search_date()
         form_data['controlsAscx111$btnDemoConsultar'] = 'Consultar'
-        form_data['controlsAscx113$cboAno'] = '2018'
         form_data['PG'] = ''
         form_data['scrollLeft'] = 0
         form_data['scrollTop'] = 0

--- a/src/settings/local.py.dist
+++ b/src/settings/local.py.dist
@@ -52,7 +52,7 @@ if mailgun.enable:
     #mailgun['html'] = 'MAIL HTML BODY'
 
 # Push Bullet Notification - Enable?
-pushbullet = ObjectDic({'enable': True})
+pushbullet = ObjectDic({'enable': False})
 
 # Push Bullet Notification
 if pushbullet.enable:


### PR DESCRIPTION
Because of the field informe de rendimento changes every year, the script to works because the hardcode year is no longer valid.
It seems that the field is not informed on requests, the validation is ignored and it will work all the times.